### PR TITLE
Allowed for the edge case of serializing basestring objects

### DIFF
--- a/cerial/fields.py
+++ b/cerial/fields.py
@@ -16,6 +16,9 @@ class CerialField(models.TextField):
         Serialize obj
         """
         raise NotImplemented
+        
+    def value_from_object(self, obj):
+        return self.dumps(super(CerialField, self).value_from_object(obj))
 
     def pre_save(self, obj, create):
         value = obj.__dict__[self.name]

--- a/cerial/fields.py
+++ b/cerial/fields.py
@@ -19,8 +19,17 @@ class CerialField(models.TextField):
 
     def pre_save(self, obj, create):
         value = obj.__dict__[self.name]
-        if isinstance(value, basestring) or (value is None and self.null):
+        if value is None and self.null:
             return value
+        if isinstance(value, basestring):
+            #Test deserializing string. Failure means it needs to be serialized
+            #as a string
+            try:
+                self.loads(value)
+            except Exception:
+                pass
+            else:
+                return value
         return self.dumps(value)
 
     def contribute_to_class(self, cls, name):

--- a/cerial/tests/testapp/tests.py
+++ b/cerial/tests/testapp/tests.py
@@ -46,6 +46,16 @@ class JSONTest(unittest.TestCase):
     def testUnicode(self):
         entry = self.manager.create(f={'k': u'åäö'})
         entry = self.manager.get(pk=entry.pk)
+        
+    def testString(self):
+        entry = self.manager.create(f="test")
+        entry = self.manager.get(pk=entry.pk)
+        self.assertEqual(entry.f, "test")
+
+    def testSerializedString(self):
+        entry = self.manager.create(f='{"test":"value"}')
+        entry = self.manager.get(pk=entry.pk)
+        self.assertEqual(entry.f, {"test":"value"})
         self.assertEqual(entry.f, {'k': u'åäö'})
 
 


### PR DESCRIPTION
I have added the ability to create field values which are raw strings, by testing if they are deserializable before deciding what to do with them. This means I can say Model(field="string"), and when it deserializes on loading from it will produce a string. In the existing implementation it allows you to save an non-deserializable string to the DB, and produces errors when loading from the DB.
